### PR TITLE
Pin postgres image to 16 and add CD workflow for EC2 deploy

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -1,0 +1,33 @@
+name: Deploy to AWS EC2
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true || github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
+
+      - name: Add EC2 Host to known_hosts
+        run: |
+          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Execute Deployment Script on EC2
+        run: |
+          ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} \
+                'bash /home/ubuntu/src/mate-fastapi-homework-5/commands/deploy.sh'

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: 'postgres:latest'
+    image: 'postgres:16'
     container_name: postgres_theater
     env_file:
       - .env

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: 'postgres:latest'
+    image: 'postgres:16'
     container_name: postgres_theater
     env_file:
       - .env


### PR DESCRIPTION
postgres:latest now resolves to Postgres 18+, which changed its data directory layout and broke startup against the existing volume mount path. Pin to postgres:16 in both prod and dev compose files.

Add cd-pipeline.yml to automatically deploy to the EC2 instance via SSH on push/merge to main, using the existing commands/deploy.sh.